### PR TITLE
Added parser argument to allow superusers to ignore the cluster

### DIFF
--- a/source/usr/bin/mcvirt
+++ b/source/usr/bin/mcvirt
@@ -40,6 +40,7 @@ if __name__ == "__main__":
         try:
             parser_object.parse_arguments()
         except MCVirtException, e:
+            #raise
             print e.message
             sys.exit(1)
     else:

--- a/source/usr/bin/mcvirt
+++ b/source/usr/bin/mcvirt
@@ -40,7 +40,6 @@ if __name__ == "__main__":
         try:
             parser_object.parse_arguments()
         except MCVirtException, e:
-            #raise
             print e.message
             sys.exit(1)
     else:

--- a/source/usr/lib/mcvirt/auth.py
+++ b/source/usr/lib/mcvirt/auth.py
@@ -29,7 +29,8 @@ class Auth:
                                        'MANAGE_VM_USERS', 'VIEW_VNC_CONSOLE', 'CLONE_VM',
                                        'DELETE_CLONE', 'MANAGE_HOST_NETWORKS', 'MANAGE_CLUSTER',
                                        'MANAGE_DRBD', 'CAN_IGNORE_DRBD', 'MIGRATE_VM',
-                                       'DUPLICATE_VM', 'SET_VM_LOCK', 'BACKUP_VM'])
+                                       'DUPLICATE_VM', 'SET_VM_LOCK', 'BACKUP_VM',
+                                       'CAN_IGNORE_CLUSTER'])
 
     # Set the permissions for the permissions groups
     PERMISSION_GROUPS = \

--- a/source/usr/lib/mcvirt/cluster/cluster.py
+++ b/source/usr/lib/mcvirt/cluster/cluster.py
@@ -38,7 +38,7 @@ class RemoteObjectConflict(MCVirtException):
     pass
 
 
-class ClusterNotInitailised(MCVirtException):
+class ClusterNotInitailisedException(MCVirtException):
     """The cluster has not been initialised, so cannot connect to the remote node"""
     pass
 
@@ -265,8 +265,8 @@ class Cluster:
         from mcvirt.cluster.remote import Remote
 
         if (not self.mcvirt_instance.initialise_nodes):
-            raise ClusterNotInitailised('Cannot get remote node %s' % node +
-                                        ' as the cluster is not initialised')
+            raise ClusterNotInitailisedException('Cannot get remote node %s' % node +
+                                                 ' as the cluster is not initialised')
 
         if (node not in self.mcvirt_instance.remote_nodes):
             self.mcvirt_instance.remote_nodes[node] = Remote(self, node)

--- a/source/usr/lib/mcvirt/cluster/cluster.py
+++ b/source/usr/lib/mcvirt/cluster/cluster.py
@@ -38,6 +38,11 @@ class RemoteObjectConflict(MCVirtException):
     pass
 
 
+class ClusterNotInitailised(MCVirtException):
+    """The cluster has not been initialised, so cannot connect to the remote node"""
+    pass
+
+
 class Cluster:
     """Class to perform node management within the MCVirt cluster"""
 
@@ -242,12 +247,27 @@ class Cluster:
 
     def connectNodes(self):
         """Obtains connection to each of the nodes"""
-        for node in self.getNodes():
-            self.getRemoteNode(node)
+        from remote import CouldNotConnectToNodeException
+        nodes = self.getNodes()
+        try:
+            for node in nodes:
+                self.getRemoteNode(node)
+        except CouldNotConnectToNodeException, e:
+            if (self.mcvirt_instance.ignore_cluster):
+                self.mcvirt_instance.initialise_nodes = False
+                for node in self.mcvirt_instance.remote_nodes:
+                    self.mcvirt_instance.remote_nodes[node]
+            else:
+                raise
 
     def getRemoteNode(self, node):
         """Obtains a Remote object for a node, caching the object"""
-        from remote import Remote
+        from mcvirt.cluster.remote import Remote
+
+        if (not self.mcvirt_instance.initialise_nodes):
+            raise ClusterNotInitailised('Cannot get remote node %s' % node +
+                                        ' as the cluster is not initialised')
+
         if (node not in self.mcvirt_instance.remote_nodes):
             self.mcvirt_instance.remote_nodes[node] = Remote(self, node)
         return self.mcvirt_instance.remote_nodes[node]

--- a/source/usr/lib/mcvirt/cluster/remote.py
+++ b/source/usr/lib/mcvirt/cluster/remote.py
@@ -367,7 +367,14 @@ class Remote:
             except AuthenticationException:
                 raise NodeAuthenticationException('Could not authenticate to node: %s' % self.name)
             except Exception:
-                raise CouldNotConnectToNodeException('Could not connect to node: %s' % self.name)
+                from mcvirt.auth import Auth
+
+                if (Auth().checkPermission(Auth.PERMISSIONS.CAN_IGNORE_CLUSTER)):
+                    ignore_cluster_message = "\nThe cluster can be ignored using --ignore-cluster"
+                else:
+                    ignore_cluster_message = ''
+                raise CouldNotConnectToNodeException('Could not connect to node: %s' % self.name +
+                                                     ignore_cluster_message)
 
             # Save the SSH client object
             self.connection = ssh_client

--- a/source/usr/lib/mcvirt/mcvirt.py
+++ b/source/usr/lib/mcvirt/mcvirt.py
@@ -148,7 +148,7 @@ class MCVirt:
         table.header(('VM Name', 'State', 'Node'))
 
         for vm_object in self.getAllVirtualMachineObjects():
-            table.add_row((vm_object.getName(), vm_object.getStateText(),
+            table.add_row((vm_object.getName(), vm_object.getState().name,
                            vm_object.getNode()))
         print table.draw()
 

--- a/source/usr/lib/mcvirt/mcvirt.py
+++ b/source/usr/lib/mcvirt/mcvirt.py
@@ -35,7 +35,8 @@ class MCVirt:
     LOCK_FILE_DIR = '/var/run/lock/mcvirt'
     LOCK_FILE = LOCK_FILE_DIR + '/lock'
 
-    def __init__(self, uri=None, initialise_nodes=True, username=None):
+    def __init__(self, uri=None, initialise_nodes=True, username=None,
+                 ignore_cluster=False):
         """Checks lock file and performs initial connection to libvirt"""
         self.libvirt_uri = uri
         self.connection = None
@@ -44,6 +45,7 @@ class MCVirt:
 
         # Configure custom username - used for unittests
         self.ignore_drbd = False
+        self.ignore_cluster = ignore_cluster
         self.username = username
 
         # Cluster configuration

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -49,10 +49,11 @@ class Parser:
         auth_object = Auth()
 
         if (auth_object.checkPermission(Auth.PERMISSIONS.CAN_IGNORE_CLUSTER)):
-          self.parent_parser.add_argument('--ignore-cluster', dest='ignore_cluster',
-                                   help='Ignores the cluster state', action='store_true')
-          self.parent_parser.add_argument('--accept-cluster-warning', dest='accept_cluster_warning',
-                                          help=argparse.SUPPRESS, action='store_true')
+            self.parent_parser.add_argument('--ignore-cluster', dest='ignore_cluster',
+                                            help='Ignores the cluster state', action='store_true')
+            self.parent_parser.add_argument('--accept-cluster-warning',
+                                            dest='accept_cluster_warning',
+                                            help=argparse.SUPPRESS, action='store_true')
 
         argparser_description = "\nMCVirt - Managed Consistent Virtualisation\n" + \
                                 'Manage the MCVirt host'

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -26,6 +26,7 @@ from node.network import Network
 from cluster.cluster import Cluster
 from system import System
 from node.drbd import DRBD as NodeDRBD
+from auth import Auth
 
 
 class ThrowingArgumentParser(argparse.ArgumentParser):
@@ -45,6 +46,13 @@ class Parser:
         """Configures the argument parser object"""
         self.print_status = print_status
         self.parent_parser = ThrowingArgumentParser(add_help=False)
+        auth_object = Auth()
+
+        if (auth_object.checkPermission(Auth.PERMISSIONS.CAN_IGNORE_CLUSTER)):
+          self.parent_parser.add_argument('--ignore-cluster', dest='ignore_cluster',
+                                   help='Ignores the cluster state', action='store_true')
+          self.parent_parser.add_argument('--accept-cluster-warning', dest='accept_cluster_warning',
+                                          help=argparse.SUPPRESS, action='store_true')
 
         argparser_description = "\nMCVirt - Managed Consistent Virtualisation\n" + \
                                 'Manage the MCVirt host'
@@ -403,12 +411,27 @@ class Parser:
         args = self.parser.parse_args(script_args)
         action = args.action
 
+        if ('ignore_cluster' in args and args.ignore_cluster):
+            # If the user has specified to ignore the cluster,
+            # print a warning and confirm the user's answer
+            if (not args.accept_cluster_warning):
+                self.printStatus('WARNING: Running MCVirt with --ignore-cluster' +
+                                 ' can leave the cluster in an inconsistent state!')
+                continue_answer = System.getUserInput('Would you like to continue? (Y/n): ')
+
+                if (continue_answer.strip() is not 'Y'):
+                    self.printStatus('Canceled...')
+                    return
+            ignore_cluster = True
+        else:
+            ignore_cluster = False
+
         # Get an instance of MCVirt
         if (mcvirt_instance is None):
             # Add corner-case to allow host info command to not start
             # the MCVirt object, so that it can view the status of nodes in the cluster
             if not (action == 'info' and args.vm_name is None):
-                mcvirt_instance = MCVirt()
+                mcvirt_instance = MCVirt(ignore_cluster=ignore_cluster)
 
         # Perform functions on the VM based on the action passed to the script
         if (action == 'start'):

--- a/source/usr/lib/mcvirt/test/auth_tests.py
+++ b/source/usr/lib/mcvirt/test/auth_tests.py
@@ -19,14 +19,14 @@ import unittest
 
 from mcvirt.parser import Parser
 from mcvirt.mcvirt import MCVirt
-from mcvirt.virtual_machine.virtual_machine import VirtualMachine
+from mcvirt.virtual_machine.virtual_machine import VirtualMachine, PowerStates
 
 
 def stopAndDelete(mcvirt_connection, vm_name):
     """Stops and removes VMs"""
     if (VirtualMachine._checkExists(mcvirt_connection.getLibvirtConnection(), vm_name)):
         vm_object = VirtualMachine(mcvirt_connection, vm_name)
-        if (vm_object.getState()):
+        if (vm_object.getState() is PowerStates.RUNNING):
             vm_object.stop()
         vm_object.delete(True)
 

--- a/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
+++ b/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
@@ -22,7 +22,7 @@ import shutil
 from mcvirt.parser import Parser
 from mcvirt.mcvirt import MCVirt
 from mcvirt.virtual_machine.virtual_machine import (VirtualMachine,
-                                                    Powerstates
+                                                    Powerstates,
                                                     InvalidVirtualMachineNameException,
                                                     VmAlreadyExistsException,
                                                     VmDirectoryAlreadyExistsException,

--- a/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
+++ b/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
@@ -22,7 +22,7 @@ import shutil
 from mcvirt.parser import Parser
 from mcvirt.mcvirt import MCVirt
 from mcvirt.virtual_machine.virtual_machine import (VirtualMachine,
-                                                    Powerstates,
+                                                    PowerStates,
                                                     InvalidVirtualMachineNameException,
                                                     VmAlreadyExistsException,
                                                     VmDirectoryAlreadyExistsException,

--- a/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
+++ b/source/usr/lib/mcvirt/test/virtual_machine/virtual_machine_tests.py
@@ -22,6 +22,7 @@ import shutil
 from mcvirt.parser import Parser
 from mcvirt.mcvirt import MCVirt
 from mcvirt.virtual_machine.virtual_machine import (VirtualMachine,
+                                                    Powerstates
                                                     InvalidVirtualMachineNameException,
                                                     VmAlreadyExistsException,
                                                     VmDirectoryAlreadyExistsException,
@@ -45,7 +46,7 @@ def stopAndDelete(mcvirt_instance, vm_name):
             remote_node = vm_object.getNode()
 
             # Stop the VM if it is running
-            if (vm_object.getState()):
+            if (vm_object.getState() is Powerstates.RUNNING):
                 remote_node.runRemoteCommand('virtual_machine-stop',
                                              {'vm_name': test_vm_object.getName()})
             # Remove VM from remote node
@@ -63,7 +64,7 @@ def stopAndDelete(mcvirt_instance, vm_name):
                 print 'Warning: VM not registered'
                 vm_object.register()
 
-            if (vm_object.getState()):
+            if (vm_object.getState() is Powerstates.RUNNING):
                 vm_object.stop()
             vm_object.delete(True)
 

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/drbd.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/drbd.py
@@ -226,7 +226,11 @@ class DRBD(Base):
         DRBD._ensureLogicalVolumeActive(self.getConfigObject(), raw_lv)
         DRBD._ensureLogicalVolumeActive(self.getConfigObject(), meta_lv)
         self._checkDrbdStatus()
-        self._drbdSetPrimary()
+
+        # If the disk is not already set to primary, set it to primary
+        if (self._drbdGetRole()[0] is not DrbdRoleState('Primary')):
+            self._drbdSetPrimary()
+
         self._ensureBlockDeviceExists()
 
     def deactivateDisk(self):

--- a/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
+++ b/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
@@ -697,7 +697,7 @@ class VirtualMachine:
                network_interfaces=[], node=None, available_nodes=None, storage_type=None,
                auth_check=True):
         """Creates a VM and returns the virtual_machine object for it"""
-        from mcvirt.cluster.cluster import Cluster
+        from mcvirt.cluster.cluster import Cluster, ClusterNotInitailised
 
         if (auth_check):
             mcvirt_instance.getAuthObject().assertPermission(Auth.PERMISSIONS.CREATE_VM)
@@ -707,6 +707,12 @@ class VirtualMachine:
         if (bool(valid_name_re(name))):
             raise InvalidVirtualMachineNameException(
                 'Error: Invalid VM Name - VM Name can only contain 0-9 a-Z and dashes')
+
+        # Ensure the cluster has not been ignored, as VMs cannot be created with MCVirt running
+        # in this state
+        if (mcvirt_instance.ignore_cluster):
+            raise ClusterNotInitailised('VM cannot be created whilst the cluster' +
+                                        ' is not initialised')
 
         # Determine if VM already exists
         if (VirtualMachine._checkExists(mcvirt_instance, name)):

--- a/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
+++ b/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
@@ -697,7 +697,7 @@ class VirtualMachine:
                network_interfaces=[], node=None, available_nodes=None, storage_type=None,
                auth_check=True):
         """Creates a VM and returns the virtual_machine object for it"""
-        from mcvirt.cluster.cluster import Cluster, ClusterNotInitailised
+        from mcvirt.cluster.cluster import Cluster, ClusterNotInitailisedException
 
         if (auth_check):
             mcvirt_instance.getAuthObject().assertPermission(Auth.PERMISSIONS.CREATE_VM)
@@ -711,8 +711,8 @@ class VirtualMachine:
         # Ensure the cluster has not been ignored, as VMs cannot be created with MCVirt running
         # in this state
         if (mcvirt_instance.ignore_cluster):
-            raise ClusterNotInitailised('VM cannot be created whilst the cluster' +
-                                        ' is not initialised')
+            raise ClusterNotInitailisedException('VM cannot be created whilst the cluster' +
+                                                 ' is not initialised')
 
         # Determine if VM already exists
         if (VirtualMachine._checkExists(mcvirt_instance, name)):


### PR DESCRIPTION
Added warning, which must be accepted (or can be ignored through a hidden argument), when ignoring the cluster.
Stopped the creation of VMs whilst ignoring the cluster and this causes a lot of issues and there is not a clear use-case for this.
Issue #25 - Allow superusers to ignore the cluster when performing MCVirt commands