### PR TITLE
Added 'direct sync' to dd command, which stops caching of the writes during the wiping of an LV.

### DIFF
--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/base.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/base.py
@@ -339,7 +339,8 @@ class Base(object):
         lv_path = config_object._getLogicalVolumePath(name)
 
         # Create command arguments
-        command_args = ['dd', 'if=/dev/zero', 'of=%s' % lv_path, 'bs=1M', 'count=%s' % size]
+        command_args = ['dd', 'if=/dev/zero', 'of=%s' % lv_path, 'bs=1M', 'count=%s' % size,
+                        'conv=fsync', 'oflag=direct']
         try:
             # Create logical volume on local node
             System.runCommand(command_args)


### PR DESCRIPTION
This change causes no additional memory to be used during the DD, as opposed to all free memory being used, which ocurred before this change
#66 Use ionice for dd commands