### PR TITLE
Fixed parameters passed to ISO object during creating in 'addIso' method.

### DIFF
--- a/source/usr/lib/mcvirt/iso.py
+++ b/source/usr/lib/mcvirt/iso.py
@@ -124,7 +124,7 @@ class Iso:
         shutil.copy(path, mcvirt_instance.ISO_STORAGE_DIR)
         full_path = mcvirt_instance.ISO_STORAGE_DIR + '/' + filename
 
-        return Iso(filename)
+        return Iso(mcvirt_instance, filename)
 
     @staticmethod
     def getFilenameFromPath(path, append_iso=True):


### PR DESCRIPTION
Exception thrown when adding an ISO form a URL #98