### PR TITLE
Updated cache mode for DRBD-backed hard disks from directsync to writeback

### DIFF
--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/base.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/base.py
@@ -126,7 +126,7 @@ class Base(object):
         driver_xml = ET.SubElement(device_xml, 'driver')
         driver_xml.set('name', 'qemu')
         driver_xml.set('type', 'raw')
-        driver_xml.set('cache', 'directsync')
+        driver_xml.set('cache', self.CACHE_MODE)
 
         # Configure the source of the disk
         source_xml = ET.SubElement(device_xml, 'source')

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/drbd.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/drbd.py
@@ -32,6 +32,7 @@ class DRBD(Base):
     DRBD_RAW_SUFFIX = 'raw'
     DRBD_META_SUFFIX = 'meta'
     DRBD_CONFIG_TEMPLATE = MCVirt.TEMPLATE_DIR + '/drbd_resource.conf'
+    CACHE_MODE = 'writeback'
 
     def __init__(
             self,

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/local.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/local.py
@@ -22,6 +22,7 @@ class Local(Base):
     """Provides a configuration interface for local hard drive objects"""
 
     MAXIMUM_DEVICES = 4
+    CACHE_MODE = 'directsync'
 
     def __init__(self, vm_object, disk_id=None, config=None, registered=False):
         """Create config has for storing variables and run the base init method"""


### PR DESCRIPTION
Change DRBD volumes to use writeback instead of directsync #106