### PR TITLE
Added functionality to parser to avoid users having to manually edit configuration files

### DIFF
--- a/Documentation/Cluster.rst
+++ b/Documentation/Cluster.rst
@@ -37,7 +37,11 @@ When a machine is connected to a cluster, it receives the permission/network/vir
 
 The new node must be configured on separate network/VLAN for MCVirt cluster communication.
 
-The IP address that MCVirt clustering/DRBD communications will be performed over must be included in the configuration file under ``cluster_ip`` on both nodes. This can be retrieved by running ``mcvirt info``.
+The IP address that MCVirt clustering/DRBD communications will be performed over must be configured by performing the following on both nodes::
+
+    sudo mcvirt node --set-ip-address <Node cluster IP address>
+
+This configuration can be retrieved by running ``mcvirt info``.
 
 
 Joining the node to the cluster

--- a/Documentation/Permissions.rst
+++ b/Documentation/Permissions.rst
@@ -15,6 +15,11 @@ Superusers
   
   * Be logged in as root.
 
+* Superusers can be added/removed using the following::
+
+    sudo mcvirt permission --add-superuser=<username>
+    sudo mcvirt permission --delete-superuser=<username>
+
 
 Managing users
 ````````````````````````````

--- a/README.rst
+++ b/README.rst
@@ -32,14 +32,11 @@ See the `installation guide <Documentation/Installation.rst>`_ for other depende
 Configuration
 -------------
 
-Perform an initial run of MCVirt, which will create a template configuration::
+Configure the volume group that MCVirt will use to store virtual machine data.
 
-  $ sudo mcvirt
+Configure the MCVirt volume group::
 
-Add the volume group to be used for VM disks in the global MCVirt configuration::
-
-  $ vim /var/lib/mcvirt/`hostname`/config.json
-
+  $ sudo mcvirt node --set-vm-vg <Volume Group>
 
 See the `installation guide <Documentation/Installation.rst>`_ for further node configuration steps.
 

--- a/source/usr/lib/mcvirt/cluster/remote.py
+++ b/source/usr/lib/mcvirt/cluster/remote.py
@@ -97,7 +97,11 @@ class Remote:
 
         elif (action == 'auth-deleteUserPermissionGroup'):
             auth_object = mcvirt_instance.getAuthObject()
-            vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
+            if (arguments['vm_name']):
+                vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
+            else:
+                vm_object = None
+
             auth_object.deleteUserPermissionGroup(mcvirt_object=mcvirt_instance,
                                                   permission_group=arguments['permission_group'],
                                                   username=arguments['username'],
@@ -109,8 +113,12 @@ class Remote:
                 ignore_duplicate = arguments['ignore_duplicate']
             else:
                 ignore_duplicate = False
-            auth_object.addSuperuser(arguments['username'],
+            auth_object.addSuperuser(arguments['username'], mcvirt_object=mcvirt_instance,
                                      ignore_duplicate=ignore_duplicate)
+
+        elif (action == 'auth-deleteSuperuser'):
+            auth_object = mcvirt_instance.getAuthObject()
+            auth_object.deleteSuperuser(arguments['username'], mcvirt_object=mcvirt_instance)
 
         elif (action == 'virtual_machine-create'):
             VirtualMachine.create(mcvirt_instance, arguments['vm_name'], arguments['cpu_cores'],

--- a/source/usr/lib/mcvirt/config_file.py
+++ b/source/usr/lib/mcvirt/config_file.py
@@ -143,7 +143,7 @@ class ConfigFile():
         from auth import Auth
         from cluster.cluster import Cluster
         if (self._checkGitRepo()):
-            message += "\nUser: %s\nNode: %s" % (Auth.getUsername(), Cluster.getHostname())
+            message += "\nUser: %s\nNode: %s" % (Auth.getLogin(), Cluster.getHostname())
             try:
                 System.runCommand([self.GIT, 'add', self.config_file], cwd=MCVirt.BASE_STORAGE_DIR)
                 System.runCommand([self.GIT,
@@ -166,7 +166,7 @@ class ConfigFile():
         from auth import Auth
         from cluster.cluster import Cluster
         if (self._checkGitRepo()):
-            message += "\nUser: %s\nNode: %s" % (Auth.getUsername(), Cluster.getHostname())
+            message += "\nUser: %s\nNode: %s" % (Auth.getLogin(), Cluster.getHostname())
             try:
                 System.runCommand([self.GIT,
                                    'rm',

--- a/source/usr/lib/mcvirt/node/node.py
+++ b/source/usr/lib/mcvirt/node/node.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2014 - I.T. Dev Ltd
+#
+# This file is part of MCVirt.
+#
+# MCVirt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MCVirt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
+
+import re
+
+from mcvirt.mcvirt import MCVirtException
+from mcvirt.mcvirt_config import MCVirtConfig
+
+
+class InvalidVolumeGroupNameException(MCVirtException):
+    """The specified name of the volume group is invalid"""
+    pass
+
+
+class InvalidIPAddressException(MCVirtException):
+    """The specified IP address is invalid"""
+    pass
+
+
+class Node(object):
+
+  @staticmethod
+  def setStorageVolumeGroup(mcvirt_instance, volume_group):
+      """Update the MCVirt configuration to set the volume group for VM storage"""
+      # Ensure volume_group name is valid
+      pattern = re.compile("^[A-Z0-9a-z]+$")
+      if (not pattern.match(volume_group)):
+          raise InvalidVolumeGroupNameException('%s is not a valid volume group name' % volume_group)
+
+      # Update global MCVirt configuration
+      def updateConfig(config):
+          config['vm_storage_vg'] = volume_group
+      mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
+      mcvirt_config.updateConfig(updateConfig, 'Set virtual machine storage volume group to %s' %
+                                               volume_group)
+
+
+  @staticmethod
+  def setClusterIpAddress(mcvirt_instance, ip_address):
+      """Updates the cluster IP address for the node"""
+      # Check validity of IP address (mainly to ensure that )
+      pattern = re.compile(r"^((([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])[ (\[]?(\.|dot)[ )\]]?){3}([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))$")
+      if not pattern.match(ip_address):
+        raise InvalidIPAddressException('%s is not a valid IP address' % ip_address)
+
+      # Update global MCVirt configuration
+      def updateConfig(config):
+          config['cluster']['cluster_ip'] = ip_address
+      mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
+      mcvirt_config.updateConfig(updateConfig, 'Set node cluster IP address to %s' %
+                                               ip_address)

--- a/source/usr/lib/mcvirt/node/node.py
+++ b/source/usr/lib/mcvirt/node/node.py
@@ -33,33 +33,34 @@ class InvalidIPAddressException(MCVirtException):
 
 class Node(object):
 
-  @staticmethod
-  def setStorageVolumeGroup(mcvirt_instance, volume_group):
-      """Update the MCVirt configuration to set the volume group for VM storage"""
-      # Ensure volume_group name is valid
-      pattern = re.compile("^[A-Z0-9a-z]+$")
-      if (not pattern.match(volume_group)):
-          raise InvalidVolumeGroupNameException('%s is not a valid volume group name' % volume_group)
+    @staticmethod
+    def setStorageVolumeGroup(mcvirt_instance, volume_group):
+        """Update the MCVirt configuration to set the volume group for VM storage"""
+        # Ensure volume_group name is valid
+        pattern = re.compile("^[A-Z0-9a-z]+$")
+        if (not pattern.match(volume_group)):
+            raise InvalidVolumeGroupNameException('%s is not a valid volume group name' %
+                                                  volume_group)
 
-      # Update global MCVirt configuration
-      def updateConfig(config):
-          config['vm_storage_vg'] = volume_group
-      mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
-      mcvirt_config.updateConfig(updateConfig, 'Set virtual machine storage volume group to %s' %
-                                               volume_group)
+        # Update global MCVirt configuration
+        def updateConfig(config):
+            config['vm_storage_vg'] = volume_group
+        mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
+        mcvirt_config.updateConfig(updateConfig, 'Set virtual machine storage volume group to %s' %
+                                                 volume_group)
 
+    @staticmethod
+    def setClusterIpAddress(mcvirt_instance, ip_address):
+        """Updates the cluster IP address for the node"""
+        # Check validity of IP address (mainly to ensure that )
+        pattern = re.compile(r"^((([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])[ (\[]?(\.|dot)"
+                             "[ )\]]?){3}([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))$")
+        if not pattern.match(ip_address):
+            raise InvalidIPAddressException('%s is not a valid IP address' % ip_address)
 
-  @staticmethod
-  def setClusterIpAddress(mcvirt_instance, ip_address):
-      """Updates the cluster IP address for the node"""
-      # Check validity of IP address (mainly to ensure that )
-      pattern = re.compile(r"^((([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])[ (\[]?(\.|dot)[ )\]]?){3}([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))$")
-      if not pattern.match(ip_address):
-        raise InvalidIPAddressException('%s is not a valid IP address' % ip_address)
-
-      # Update global MCVirt configuration
-      def updateConfig(config):
-          config['cluster']['cluster_ip'] = ip_address
-      mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
-      mcvirt_config.updateConfig(updateConfig, 'Set node cluster IP address to %s' %
-                                               ip_address)
+        # Update global MCVirt configuration
+        def updateConfig(config):
+            config['cluster']['cluster_ip'] = ip_address
+        mcvirt_config = MCVirtConfig(mcvirt_instance=mcvirt_instance)
+        mcvirt_config.updateConfig(updateConfig, 'Set node cluster IP address to %s' %
+                                                 ip_address)

--- a/source/usr/lib/mcvirt/node/node.py
+++ b/source/usr/lib/mcvirt/node/node.py
@@ -37,7 +37,7 @@ class Node(object):
     def setStorageVolumeGroup(mcvirt_instance, volume_group):
         """Update the MCVirt configuration to set the volume group for VM storage"""
         # Ensure volume_group name is valid
-        pattern = re.compile("^[A-Z0-9a-z]+$")
+        pattern = re.compile("^[A-Z0-9a-z_-]+$")
         if (not pattern.match(volume_group)):
             raise InvalidVolumeGroupNameException('%s is not a valid volume group name' %
                                                   volume_group)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -239,7 +239,9 @@ class Parser:
             type=str,
             help='Removes a given user from the superuser group'
         )
-        self.permission_target_group = self.permission_parser.add_mutually_exclusive_group(required=True)
+        self.permission_target_group = self.permission_parser.add_mutually_exclusive_group(
+            required=True
+        )
         self.permission_target_group.add_argument('vm_name', metavar='VM Name',
                                                   type=str, help='Name of VM', nargs='?')
         self.permission_target_group.add_argument('--global', dest='global', action='store_true',
@@ -417,9 +419,10 @@ class Parser:
         self.node_parser.add_argument('--set-vm-vg', dest='volume_group', metavar='VM Volume Group',
                                       help=('Sets the local volume group used for Virtual'
                                             ' machine HDD logical volumes'))
-        self.node_parser.add_argument('--set-ip-address', dest='ip_address', metavar='Cluster IP Address',
-                                      help=('Sets the cluster IP address for the local node, used for'
-                                            ' DRBD and cluster management.'))
+        self.node_parser.add_argument('--set-ip-address', dest='ip_address',
+                                      metavar='Cluster IP Address',
+                                      help=('Sets the cluster IP address for the local node,'
+                                            ' used for DRBD and cluster management.'))
 
         # Create subparser for VM verification
         self.verify_parser = self.subparsers.add_parser(
@@ -758,7 +761,8 @@ class Parser:
         elif (action == 'node'):
             if (args.volume_group):
                 Node.setStorageVolumeGroup(mcvirt_instance, args.volume_group)
-                self.printStatus('Successfully set VM storage volume group to %s' % args.volume_group)
+                self.printStatus('Successfully set VM storage volume group to %s' %
+                                 args.volume_group)
 
             if (args.ip_address):
                 Node.setClusterIpAddress(mcvirt_instance, args.ip_address)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -26,6 +26,7 @@ from node.network import Network
 from cluster.cluster import Cluster
 from system import System
 from node.drbd import DRBD as NodeDRBD
+from node.node import Node
 from auth import Auth
 from iso import Iso
 
@@ -198,19 +199,19 @@ class Parser:
         self.permission_parser.add_argument(
             '--add-user',
             dest='add_user',
-            metavar='Add User',
+            metavar='Add user to user group',
             type=str,
             help='Adds a given user to a VM, allowing them to perform basic functions.')
         self.permission_parser.add_argument(
             '--delete-user',
             dest='delete_user',
-            metavar='Delete User',
+            metavar='Remove user from user group',
             type=str,
             help='Removes a given user from a VM. This prevents them to perform basic functions.')
         self.permission_parser.add_argument(
             '--add-owner',
             dest='add_owner',
-            metavar='Add Owner',
+            metavar='Add user to owner group',
             type=str,
             help=('Adds a given user as an owner to a VM, '
                   'allowing them to perform basic functions and manager users.')
@@ -218,13 +219,31 @@ class Parser:
         self.permission_parser.add_argument(
             '--delete-owner',
             dest='delete_owner',
-            metavar='Delete User',
+            metavar='Remove user from owner group',
             type=str,
             help=('Removes a given owner from a VM. '
                   'This prevents them to perform basic functions and manager users.')
         )
-        self.permission_parser.add_argument('vm_name', metavar='VM Name',
-                                            type=str, help='Name of VM')
+        self.permission_parser.add_argument(
+            '--add-superuser',
+            dest='add_superuser',
+            metavar='Add user to superuser group',
+            type=str,
+            help=('Adds a given user to the global superuser role. '
+                  'This allows the user to completely manage the MCVirt node/cluster')
+        )
+        self.permission_parser.add_argument(
+            '--delete-superuser',
+            dest='delete_superuser',
+            metavar='Removes user from the superuser group',
+            type=str,
+            help='Removes a given user from the superuser group'
+        )
+        self.permission_target_group = self.permission_parser.add_mutually_exclusive_group(required=True)
+        self.permission_target_group.add_argument('vm_name', metavar='VM Name',
+                                                  type=str, help='Name of VM', nargs='?')
+        self.permission_target_group.add_argument('--global', dest='global', action='store_true',
+                                                  help='Set a global MCVirt permission')
 
         # Create subparser for network-related commands
         self.network_parser = self.subparsers.add_parser(
@@ -388,6 +407,19 @@ class Parser:
             type=str,
             required=True,
             help='Hostname of the remote node to remove from the cluster')
+
+        # Create subparser for commands relating to the local node configuration
+        self.node_parser = self.subparsers.add_parser(
+            'node',
+            help='Modify configurations relating to the local node',
+            parents=[self.parent_parser]
+        )
+        self.node_parser.add_argument('--set-vm-vg', dest='volume_group', metavar='VM Volume Group',
+                                      help=('Sets the local volume group used for Virtual'
+                                            ' machine HDD logical volumes'))
+        self.node_parser.add_argument('--set-ip-address', dest='ip_address', metavar='Cluster IP Address',
+                                      help=('Sets the cluster IP address for the local node, used for'
+                                            ' DRBD and cluster management.'))
 
         # Create subparser for VM verification
         self.verify_parser = self.subparsers.add_parser(
@@ -615,7 +647,16 @@ class Parser:
                 harddrive_object.increaseSize(args.increase_disk)
 
         elif (action == 'permission'):
-            vm_object = VirtualMachine(mcvirt_instance, args.vm_name)
+            if ((args.add_superuser or args.delete_superuser) and args.vm_name):
+                raise MCVirtException('Superuser groups are global-only roles')
+
+            if (args.vm_name):
+                vm_object = VirtualMachine(mcvirt_instance, args.vm_name)
+                permission_destination_string = 'role on VM %s' % vm_object.getName()
+            else:
+                vm_object = None
+                permission_destination_string = 'global role'
+
             auth_object = mcvirt_instance.getAuthObject()
             if (args.add_user):
                 auth_object.addUserPermissionGroup(
@@ -624,8 +665,9 @@ class Parser:
                     username=args.add_user,
                     vm_object=vm_object)
                 self.printStatus(
-                    'Successfully added \'%s\' as \'user\' to VM \'%s\'' %
-                    (args.add_user, vm_object.getName()))
+                    'Successfully added \'%s\' to \'user\' %s' %
+                    (args.add_user, permission_destination_string))
+
             if (args.delete_user):
                 auth_object.deleteUserPermissionGroup(
                     mcvirt_object=mcvirt_instance,
@@ -633,8 +675,9 @@ class Parser:
                     username=args.delete_user,
                     vm_object=vm_object)
                 self.printStatus(
-                    'Successfully removed \'%s\' as \'user\' from VM \'%s\'' %
-                    (args.delete_user, vm_object.getName()))
+                    'Successfully removed \'%s\' from \'user\' %s' %
+                    (args.delete_user, permission_destination_string))
+
             if (args.add_owner):
                 auth_object.addUserPermissionGroup(
                     mcvirt_object=mcvirt_instance,
@@ -642,8 +685,9 @@ class Parser:
                     username=args.add_owner,
                     vm_object=vm_object)
                 self.printStatus(
-                    'Successfully added \'%s\' as \'owner\' to VM \'%s\'' %
-                    (args.add_owner, vm_object.getName()))
+                    'Successfully added \'%s\' to \'owner\' %s' %
+                    (args.add_owner, permission_destination_string))
+
             if (args.delete_owner):
                 auth_object.deleteUserPermissionGroup(
                     mcvirt_object=mcvirt_instance,
@@ -651,8 +695,17 @@ class Parser:
                     username=args.delete_owner,
                     vm_object=vm_object)
                 self.printStatus(
-                    'Successfully added \'%s\' as \'owner\' from VM \'%s\'' %
-                    (args.delete_owner, vm_object.getName()))
+                    'Successfully removed \'%s\' from \'owner\' %s' %
+                    (args.delete_owner, permission_destination_string))
+
+            if (args.add_superuser):
+                auth_object.addSuperuser(args.add_superuser, mcvirt_object=mcvirt_instance)
+                self.printStatus('Successfully added %s to the global superuser group' %
+                                 args.add_superuser)
+            if (args.delete_superuser):
+                auth_object.deleteSuperuser(args.delete_superuser, mcvirt_object=mcvirt_instance)
+                self.printStatus('Successfully removed %s from the global superuser group ' %
+                                 args.delete_superuser)
 
         elif (action == 'info'):
             if (not args.vm_name and (args.vnc_port or args.node)):
@@ -701,6 +754,15 @@ class Parser:
                 cluster_object = Cluster(mcvirt_instance)
                 cluster_object.removeNode(args.node)
                 self.printStatus('Successfully removed node %s' % args.node)
+
+        elif (action == 'node'):
+            if (args.volume_group):
+                Node.setStorageVolumeGroup(mcvirt_instance, args.volume_group)
+                self.printStatus('Successfully set VM storage volume group to %s' % args.volume_group)
+
+            if (args.ip_address):
+                Node.setClusterIpAddress(mcvirt_instance, args.ip_address)
+                self.printStatus('Successfully set cluster IP address to %s' % args.ip_address)
 
         elif (action == 'verify'):
             if (args.vm_name):

--- a/source/usr/lib/mcvirt/test/auth_tests.py
+++ b/source/usr/lib/mcvirt/test/auth_tests.py
@@ -18,8 +18,9 @@
 import unittest
 
 from mcvirt.parser import Parser
-from mcvirt.mcvirt import MCVirt
+from mcvirt.mcvirt import MCVirt, MCVirtException
 from mcvirt.virtual_machine.virtual_machine import VirtualMachine, PowerStates
+from mcvirt.auth import Auth, InsufficientPermissionsException
 
 
 def stopAndDelete(mcvirt_connection, vm_name):
@@ -31,6 +32,24 @@ def stopAndDelete(mcvirt_connection, vm_name):
         vm_object.delete(True)
 
 
+def removeTestUserPermissions(mcvirt_instance, username):
+    """Removes the test user from all permission groups"""
+    auth_object = mcvirt_instance.getAuthObject()
+
+    try:
+        auth_object.deleteUserPermissionGroup(mcvirt_instance, 'user', username)
+    except:
+        pass
+    try:
+        auth_object.deleteUserPermissionGroup(mcvirt_instance, 'user', username)
+    except:
+        pass
+    try:
+        auth_object.deleteSuperuser(username, mcvirt_instance)
+    except:
+        pass
+
+
 class AuthTests(unittest.TestCase):
     """Provides unit tests for the Auth class"""
 
@@ -40,6 +59,10 @@ class AuthTests(unittest.TestCase):
         suite = unittest.TestSuite()
         suite.addTest(AuthTests('test_add_user'))
         suite.addTest(AuthTests('test_remove_user'))
+        suite.addTest(AuthTests('test_add_delete_superuser'))
+        suite.addTest(AuthTests('test_attempt_add_superuser_to_vm'))
+        suite.addTest(AuthTests('test_add_duplicate_superuser'))
+        suite.addTest(AuthTests('test_delete_non_existant_superuser'))
         return suite
 
     def setUp(self):
@@ -61,14 +84,18 @@ class AuthTests(unittest.TestCase):
             }
 
         self.test_user = 'test_user'
+        self.test_auth_object = Auth(self.test_user)
+        self.auth_object = Auth()
 
         # Ensure any test VM is stopped and removed from the machine
         stopAndDelete(self.mcvirt, self.test_vm['name'])
+        removeTestUserPermissions(self.mcvirt, self.test_user)
 
     def tearDown(self):
         """Stops and tears down any test VMs"""
         # Ensure any test VM is stopped and removed from the machine
         stopAndDelete(self.mcvirt, self.test_vm['name'])
+        removeTestUserPermissions(self.mcvirt, self.test_user)
         self.mcvirt = None
 
     def test_add_user(self):
@@ -87,9 +114,8 @@ class AuthTests(unittest.TestCase):
                 self.test_vm['name']))
 
         # Ensure user is not in 'user' group
-        auth_object = self.mcvirt.getAuthObject()
         self.assertFalse(
-            self.test_user in auth_object.getUsersInPermissionGroup(
+            self.test_user in self.auth_object.getUsersInPermissionGroup(
                 'user',
                 test_vm_object))
 
@@ -102,7 +128,7 @@ class AuthTests(unittest.TestCase):
 
         # Ensure VM exists
         self.assertTrue(
-            self.test_user in auth_object.getUsersInPermissionGroup(
+            self.test_user in self.auth_object.getUsersInPermissionGroup(
                 'user',
                 test_vm_object))
 
@@ -122,10 +148,10 @@ class AuthTests(unittest.TestCase):
                 self.test_vm['name']))
 
         # Add user to 'user' group and ensure they have been added
-        auth_object = self.mcvirt.getAuthObject()
-        auth_object.addUserPermissionGroup(self.mcvirt, 'user', self.test_user, test_vm_object)
+        self.auth_object.addUserPermissionGroup(self.mcvirt, 'user', self.test_user,
+                                                test_vm_object)
         self.assertTrue(
-            self.test_user in auth_object.getUsersInPermissionGroup(
+            self.test_user in self.auth_object.getUsersInPermissionGroup(
                 'user',
                 test_vm_object))
 
@@ -138,6 +164,66 @@ class AuthTests(unittest.TestCase):
 
         # Ensure user is no longer in 'user' group
         self.assertFalse(
-            self.test_user in auth_object.getUsersInPermissionGroup(
+            self.test_user in self.auth_object.getUsersInPermissionGroup(
                 'user',
                 test_vm_object))
+
+    def test_add_delete_superuser(self):
+        """Adds/deletes a user to/from the superuser role"""
+        # Assert that the user is not already a superuser
+        self.assertFalse(self.test_auth_object.isSuperuser())
+
+        # Add the user to the superuser group using the argument parser
+        self.parser.parse_arguments('permission --add-superuser %s --global' % self.test_user,
+                                    mcvirt_instance=self.mcvirt)
+
+        # Ensure that the auth object asserts that the user is a superuser
+        self.assertTrue(self.test_auth_object.isSuperuser())
+
+        # Assert that the user has access to a superuser permission
+        self.assertTrue(
+            self.test_auth_object.assertPermission(Auth.PERMISSIONS.TEST_SUPERUSER_PERMISSION)
+        )
+
+        # Delete the user from the superuser group using the argument parser
+        self.parser.parse_arguments('permission --delete-superuser %s --global' % self.test_user,
+                                    mcvirt_instance=self.mcvirt)
+
+        # Assert that the user is no longer considered a superuser
+        self.assertFalse(self.test_auth_object.isSuperuser())
+
+        # Assert that the user no longer has access to the superuser permission
+        with self.assertRaises(InsufficientPermissionsException):
+            self.test_auth_object.assertPermission(Auth.PERMISSIONS.TEST_SUPERUSER_PERMISSION)
+
+    def test_attempt_add_superuser_to_vm(self):
+        """Attempts to add a user as a superuser to a VM"""
+        test_vm_object = VirtualMachine.create(
+            self.mcvirt,
+            self.test_vm['name'],
+            self.test_vm['cpu_count'],
+            self.test_vm['memory_allocation'],
+            self.test_vm['disks'],
+            self.test_vm['networks']
+        )
+
+        with self.assertRaises(MCVirtException):
+            self.parser.parse_arguments('permission --add-superuser %s %s' %
+                                        (self.test_user, self.test_vm['name']),
+                                        mcvirt_instance=self.mcvirt)
+
+    def test_add_duplicate_superuser(self):
+        """Attempts to add a superuser twice"""
+        # Add the user as a superuser
+        self.auth_object.addSuperuser(self.test_user, self.mcvirt)
+
+        with self.assertRaises(MCVirtException):
+            self.parser.parse_arguments('permission --add-superuser %s --global' % self.test_user,
+                                        mcvirt_instance=self.mcvirt)
+
+    def test_delete_non_existant_superuser(self):
+        """Attempts to remove a non-existent user from the superuser group"""
+        with self.assertRaises(MCVirtException):
+            self.parser.parse_arguments('permission --delete-superuser %s --global' %
+                                        self.test_user,
+                                        mcvirt_instance=self.mcvirt)

--- a/source/usr/lib/mcvirt/test/node/node_tests.py
+++ b/source/usr/lib/mcvirt/test/node/node_tests.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2014 - I.T. Dev Ltd
+#
+# This file is part of MCVirt.
+#
+# MCVirt is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# MCVirt is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
+
+import unittest
+
+from mcvirt.parser import Parser
+from mcvirt.mcvirt import MCVirt
+from mcvirt.node.node import Node, InvalidIPAddressException, InvalidVolumeGroupNameException
+from mcvirt.mcvirt_config import MCVirtConfig
+
+
+class NodeTests(unittest.TestCase):
+    """Provides unit tests for the functionality
+       provided by the node subparser"""
+
+    @staticmethod
+    def suite():
+        """Returns a test suite"""
+        suite = unittest.TestSuite()
+        suite.addTest(NodeTests('test_set_ip_address'))
+        suite.addTest(NodeTests('test_set_invalid_ip_address'))
+        suite.addTest(NodeTests('test_set_volume_group'))
+        suite.addTest(NodeTests('test_set_invalid_volume_group'))
+        return suite
+
+    def setUp(self):
+        """Creates various objects and deletes any test VMs"""
+        # Create MCVirt parser object
+        self.parser = Parser(print_status=False)
+
+        # Get an MCVirt instance
+        self.mcvirt = MCVirt()
+
+        self.original_ip_address = MCVirtConfig().getConfig()['cluster']['cluster_ip']
+        self.original_volume_group = MCVirtConfig().getConfig()['vm_storage_vg']
+
+    def tearDown(self):
+        """Resets any values changed to the MCVirt config"""
+        Node.setClusterIpAddress(self.mcvirt, self.original_ip_address)
+        Node.setStorageVolumeGroup(self.mcvirt, self.original_volume_group)
+        self.mcvirt = None
+
+    def test_set_ip_address(self):
+        """Changes the cluster IP address using the argument parser"""
+        test_ip_address = '1.1.1.1'
+        self.parser.parse_arguments('node --set-ip-address %s' %
+                                    test_ip_address,
+                                    mcvirt_instance=self.mcvirt)
+        self.assertEqual(MCVirtConfig().getConfig()['cluster']['cluster_ip'], test_ip_address)
+
+    def test_set_invalid_ip_address(self):
+        test_fake_ip_addresses = [
+            '1.1.1.256', 'test_string', '1.1.1', '1.2.3.4a'
+        ]
+        for ip_address in test_fake_ip_addresses:
+            with self.assertRaises(InvalidIPAddressException):
+                self.parser.parse_arguments('node --set-ip-address %s' %
+                                            ip_address,
+                                            mcvirt_instance=self.mcvirt)
+
+    def test_set_volume_group(self):
+        """Changes the cluster IP address using the argument parser"""
+        test_vg = 'test-vg_name'
+        self.parser.parse_arguments('node --set-vm-vg %s' % test_vg,
+                                    mcvirt_instance=self.mcvirt)
+        self.assertEqual(MCVirtConfig().getConfig()['vm_storage_vg'], test_vg)
+
+    def test_set_invalid_volume_group(self):
+        test_fake_volume_groups = ('[adg', 'vg;', '@vg_name')
+        for volume_group in test_fake_volume_groups:
+            with self.assertRaises(InvalidVolumeGroupNameException):
+                self.parser.parse_arguments('node --set-vm-vg %s' % volume_group,
+                                            mcvirt_instance=self.mcvirt)

--- a/source/usr/lib/mcvirt/test/run_tests.py
+++ b/source/usr/lib/mcvirt/test/run_tests.py
@@ -21,6 +21,7 @@ import unittest
 sys.path.insert(0, '/usr/lib')
 
 from mcvirt.test.node.network_tests import NetworkTests
+from mcvirt.test.node.node_tests import NodeTests
 from mcvirt.test.virtual_machine.virtual_machine_tests import VirtualMachineTests
 from mcvirt.test.auth_tests import AuthTests
 from mcvirt.test.virtual_machine.hard_drive.drbd_tests import DrbdTests
@@ -33,7 +34,8 @@ if __name__ == '__main__':
     network_test_suite = NetworkTests.suite()
     drbd_test_suite = DrbdTests.suite()
     update_test_suite = UpdateTests.suite()
+    node_test_suite = NodeTests.suite()
     all_tests = unittest.TestSuite(
         [virtual_machine_test_suite, network_test_suite, auth_test_suite,
-         drbd_test_suite, update_test_suite])
+         drbd_test_suite, update_test_suite, node_test_suite])
     sys.exit(not runner.run(all_tests).wasSuccessful())


### PR DESCRIPTION
* Added ability to add/remove users to/from the superuser group through the parser
* Added ability to set VM storage volume group and node cluster IP address
* Fixed various bugs around adding/removing users from VM/global roles

 Stop users having to directly modify the global MCVirt configuration #3 