### PR TITLE
Added online migration functionality to MCVirt

### DIFF
--- a/source/usr/lib/mcvirt/cluster/remote.py
+++ b/source/usr/lib/mcvirt/cluster/remote.py
@@ -112,6 +112,9 @@ class Remote:
             auth_object.addSuperuser(arguments['username'],
                                      ignore_duplicate=ignore_duplicate)
 
+        elif (action == 'virtual_machine-getAllVms'):
+            return_data = VirtualMachine.getAllVms(mcvirt_instance, Cluster.getHostname())
+
         elif (action == 'virtual_machine-create'):
             VirtualMachine.create(mcvirt_instance, arguments['vm_name'], arguments['cpu_cores'],
                                   arguments['memory_allocation'], node=arguments['node'],
@@ -248,11 +251,29 @@ class Remote:
             hard_drive_class = HardDriveFactory.getClass(hard_drive_config_object._getType())
             hard_drive_class._drbdDown(hard_drive_config_object)
 
+        elif (action == 'virtual_machine-hard_drive-drbd-drbdSetPrimary'):
+            from mcvirt.virtual_machine.hard_drive.factory import Factory as HardDriveFactory
+            vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
+
+            if ('allow_two_primaries' in arguments):
+                allow_two_primaries = arguments['allow_two_primaries']
+            else:
+                allow_two_primaries = False
+
+            hard_drive_object = HardDriveFactory.getObject(vm_object, arguments['disk_id'])
+            hard_drive_object._drbdSetPrimary(allow_two_primaries=allow_two_primaries)
+
         elif (action == 'virtual_machine-hard_drive-drbd-drbdSetSecondary'):
             from mcvirt.virtual_machine.hard_drive.factory import Factory as HardDriveFactory
             vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
             hard_drive_object = HardDriveFactory.getObject(vm_object, arguments['disk_id'])
             hard_drive_object._drbdSetSecondary()
+
+        elif (action == 'virtual_machine-hard_drive-drbd-setTwoPrimariesConfig'):
+            from mcvirt.virtual_machine.hard_drive.factory import Factory as HardDriveFactory
+            vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
+            hard_drive_object = HardDriveFactory.getObject(vm_object, arguments['disk_id'])
+            hard_drive_object._setTwoPrimariesConfig(arguments['allow'])
 
         elif (action == 'virtual_machine-hard_drive-drbd-drbdConnect'):
             from mcvirt.virtual_machine.hard_drive.factory import Factory as HardDriveFactory
@@ -302,6 +323,10 @@ class Remote:
             vm_object = VirtualMachine(mcvirt_instance, arguments['vm_name'])
             hard_drive_object = HardDriveFactory.getObject(vm_object, arguments['disk_id'])
             hard_drive_object.setSyncState(arguments['sync_state'])
+
+        elif (action == 'iso-getIsos'):
+            from mcvirt.iso import Iso
+            return_data = Iso.getIsos(mcvirt_instance)
 
         elif (action == 'mcvirt-obtainLock'):
             timeout = arguments['timeout']

--- a/source/usr/lib/mcvirt/iso.py
+++ b/source/usr/lib/mcvirt/iso.py
@@ -22,6 +22,12 @@ from mcvirt import MCVirtException
 from system import System
 
 
+class IsoNotPresentOnDestinationNodeException(MCVirtException):
+    """ISO attached to VM does not exist on destination node
+       whilst performing a migration"""
+    pass
+
+
 class InvalidISOPathException(MCVirtException):
     """ISO to add does not exist"""
     pass
@@ -167,23 +173,25 @@ class Iso:
         return True
 
     @staticmethod
-    def getIsoList(mcvirt_instance):
-        """Return a list of ISOs"""
-
-        list = ''
+    def getIsos(mcvirt_instance):
+        """Returns a list of a ISOs"""
         # Get files in ISO directory
-        listing = os.listdir(mcvirt_instance.ISO_STORAGE_DIR)
-        for file in listing:
-            # If is a file and ends in '.iso' ...
-            if (os.path.isfile(mcvirt_instance.ISO_STORAGE_DIR + '/' + file)):
-                if len(list) > 0:
-                    list += '\n'
-                list += file
+        file_list = os.listdir(mcvirt_instance.ISO_STORAGE_DIR)
+        iso_list = []
 
-        if (len(list) == 0):
-            list = 'No ISO found'
+        for iso_name in file_list:
+            if (os.path.isfile(mcvirt_instance.ISO_STORAGE_DIR + '/' + iso_name)):
+                iso_list.append(iso_name)
+        return iso_list
 
-        return list
+    @staticmethod
+    def getIsoList(mcvirt_instance):
+        """Return a user-readable list of ISOs"""
+        iso_list = Iso.getIsos(mcvirt_instance)
+        if (len(iso_list) == 0):
+            return 'No ISOs found'
+        else:
+            return "\n".join(iso_list)
 
     def delete(self):
         """Delete an ISO"""

--- a/source/usr/lib/mcvirt/mcvirt.py
+++ b/source/usr/lib/mcvirt/mcvirt.py
@@ -115,7 +115,7 @@ class MCVirt:
 
     def getRemoteLibvirtConnection(self, remote_node):
         """Obtains and caches connections to remote libvirt daemons"""
-        # Check is connection is already established
+        # Check if a connection has already been established
         if (remote_node.name not in self.libvirt_node_connections):
             # If not, establish a connection
             libvirt_url = 'qemu+ssh://%s/system' % remote_node.remote_ip

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -320,6 +320,12 @@ class Parser:
             help='The name of the destination node for the VM to be migrated to'
         )
         self.migrate_parser.add_argument(
+            '--online',
+            dest='online_migration',
+            help='Perform an online-migration',
+            action='store_true'
+        )
+        self.migrate_parser.add_argument(
             '--start-after-migration',
             dest='start_after_migration',
             help='Causes the VM to be booted after the migration',
@@ -680,10 +686,15 @@ class Parser:
 
         elif (action == 'migrate'):
             vm_object = VirtualMachine(mcvirt_instance, args.vm_name)
-            vm_object.offlineMigrate(
-                args.destination_node,
-                wait_for_vm_shutdown=args.wait_for_shutdown,
-                start_after_migration=args.start_after_migration)
+            if (args.online_migration):
+                vm_object.onlineMigrate(args.destination_node)
+            else:
+                vm_object.offlineMigrate(
+                    args.destination_node,
+                    wait_for_vm_shutdown=args.wait_for_shutdown,
+                    start_after_migration=args.start_after_migration)
+            self.printStatus('Successfully migrated \'%s\' to %s' %
+                             (vm_object.getName(), args.destination_node))
 
         elif (action == 'move'):
             vm_object = VirtualMachine(mcvirt_instance, args.vm_name)

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/base.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/base.py
@@ -503,9 +503,20 @@ class Base(object):
         """Deactivates the storage volume"""
         raise NotImplementedError
 
-    def offlineMigrateCheckState(self, destination_node):
+    def preMigrationChecks(self, destination_node):
         """Determines if the disk is in a state to allow the attached VM
            to be migrated to another node"""
+        raise NotImplementedError
+
+    def preOnlineMigration(self):
+        """Performs required tasks in order
+           for the underlying VM to perform an
+           online migration"""
+        raise NotImplementedError
+
+    def postOnlineMigration(self):
+        """Performs post tasks after a VM
+           has performed an online migration"""
         raise NotImplementedError
 
     def getSize(self):

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/drbd.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/config/drbd.py
@@ -32,7 +32,7 @@ class DRBD(Base):
     DRBD_RAW_SUFFIX = 'raw'
     DRBD_META_SUFFIX = 'meta'
     DRBD_CONFIG_TEMPLATE = MCVirt.TEMPLATE_DIR + '/drbd_resource.conf'
-    CACHE_MODE = 'writeback'
+    CACHE_MODE = 'none'
 
     def __init__(
             self,

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/drbd.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/drbd.py
@@ -480,7 +480,49 @@ class DRBD(Base):
         System.runCommand(
             [NodeDRBD.DRBDADM, 'disconnect', self.getConfigObject()._getResourceName()])
 
-    def _drbdSetPrimary(self):
+    def _setTwoPrimariesConfig(self, allow=False):
+        """Configures DRBD to temporarily allow or re-disable whether
+           two allow two primaries"""
+        if (allow):
+            # Configure DRBD on both nodes to allow DRBD volume to be set to primary
+            self._checkDrbdStatus()
+
+            System.runCommand([NodeDRBD.DRBDADM, 'net-options',
+                               self.getConfigObject()._getResourceName(),
+                               '--allow-two-primaries'])
+
+        else:
+            # Get disk role state
+            local_role, remote_role = self._drbdGetRole()
+
+            # Ensure neither states are unknown
+            if (local_role is DrbdRoleState.UNKNOWN or
+                    remote_role is DrbdRoleState.UNKNOWN):
+                raise DrbdStateException('Cannot disable two-primaries configuration as'
+                                         ' local or remote role is currently unknown')
+
+            # Ensure that only one node has been set to primary
+            if (local_role is DrbdRoleState.PRIMARY and
+                    remote_role is DrbdRoleState.PRIMARY):
+                raise DrbdStateException('Both nodes are set to primary whilst attempting'
+                                         ' to disable dual-primary mode')
+
+            System.runCommand([NodeDRBD.DRBDADM, 'net-options',
+                               self.getConfigObject()._getResourceName(),
+                               '--allow-two-primaries=no'])
+
+        # Config remote node(s)
+        if (self.getConfigObject().vm_object.mcvirt_object.initialiseNodes()):
+            cluster_instance = Cluster(self.getConfigObject().vm_object.mcvirt_object)
+            cluster_instance.runRemoteCommand(
+                'virtual_machine-hard_drive-drbd-setTwoPrimariesConfig',
+                {'vm_name': self.getVmObject().getName(),
+                 'disk_id': self.getConfigObject().getId(),
+                 'allow': allow},
+                nodes=self.getConfigObject().vm_object._getRemoteNodes()
+            )
+
+    def _drbdSetPrimary(self, allow_two_primaries=False):
         """Performs a DRBD 'primary' on the hard drive DRBD resource"""
         local_role_state, remote_role_state = self._drbdGetRole()
 
@@ -495,7 +537,8 @@ class DRBD(Base):
                                      self.getConfigObject()._getResourceName())
 
         # Ensure remote role is secondary
-        if (remote_role_state is not DrbdRoleState.SECONDARY and
+        if (not allow_two_primaries and
+            remote_role_state is not DrbdRoleState.SECONDARY and
             not (DrbdRoleState.UNKNOWN and
                  NodeDRBD.isIgnored(self.getVmObject().mcvirt_object))):
             raise DrbdStateException(
@@ -580,17 +623,54 @@ class DRBD(Base):
         (local_state, remote_state) = states.split('/')
         return (DrbdRoleState(local_state), DrbdRoleState(remote_state))
 
-    def offlineMigrateCheckState(self):
-        """Ensures that the DRBD state of the disk is in a state suitable for offline migration"""
+    def preMigrationChecks(self):
+        """Ensures that the DRBD state of the disk is in a state suitable for migration"""
         # Ensure disk state is up-to-date on both local and remote nodes
         local_disk_state, remote_disk_state = self._drbdGetDiskState()
+        local_role, remote_role = self._drbdGetRole()
         connection_state = self._drbdGetConnectionState()
         if ((local_disk_state is not DrbdDiskState.UP_TO_DATE) or
                 (remote_disk_state is not DrbdDiskState.UP_TO_DATE) or
-                (connection_state is not DrbdConnectionState.CONNECTED)):
+                (connection_state is not DrbdConnectionState.CONNECTED) or
+                (local_role is not DrbdRoleState.PRIMARY) or
+                (remote_role is not DrbdRoleState.SECONDARY)):
             raise DrbdStateException('DRBD resource %s is not in a suitable state to be migrated. '
                                      % self.getConfigObject()._getResourceName() +
                                      'Both nodes must be up-to-date and connected')
+
+    def preOnlineMigration(self, destination_node):
+        """Performs required tasks in order
+           for the underlying VM to perform an
+           online migration"""
+        # Temporarily allow the DRBD volume to be in a dual-primary mode
+        self._setTwoPrimariesConfig(allow=True)
+
+        # Set remote node as primary
+        destination_node.runRemoteCommand('virtual_machine-hard_drive-drbd-drbdSetPrimary',
+                                          {'vm_name': self.getVmObject().getName(),
+                                           'disk_id': self.getConfigObject().getId(),
+                                           'allow_two_primaries': True})
+
+    def postOnlineMigration(self):
+        """Performs post tasks after a VM
+           has performed an online migration"""
+        import time
+        # Set DRBD on local node as secondary
+        self._drbdSetSecondary()
+
+        # Attempt to wait for DRBD to update status to secondary
+        # If, after 15 seconds, the local volume is still not
+        # primary, let the setTwiPrimariesConfig function raise
+        # an appropriate exception
+        for i in range(1, 3):
+            local_role, _ = self._drbdGetRole()
+            if (local_role is DrbdRoleState.SECONDARY):
+                break
+            else:
+                time.sleep(5)
+
+        # Disable the DRBD volume from being a dual-primary mode
+        self._setTwoPrimariesConfig(allow=False)
 
     def _ensureBlockDeviceExists(self):
         """Ensures that the DRBD block device exists"""

--- a/source/usr/lib/mcvirt/virtual_machine/hard_drive/local.py
+++ b/source/usr/lib/mcvirt/virtual_machine/hard_drive/local.py
@@ -24,6 +24,11 @@ from mcvirt.virtual_machine.hard_drive.base import Base
 from mcvirt.virtual_machine.hard_drive.config.local import Local as ConfigLocal
 
 
+class CannotMigrateLocalDiskException(MCVirtException):
+    """Local disks cannot be migrated"""
+    pass
+
+
 class Local(Base):
     """Provides operations to manage local hard drives, used by VMs"""
 
@@ -122,3 +127,7 @@ class Local(Base):
         """Deactivates the disk loglcal volume"""
         self._ensureExists()
         pass
+
+    def preMigrationChecks(self):
+        """Perform pre-migration checks"""
+        raise CannotMigrateLocalDiskException('VMs using local disks cannot be migrated')

--- a/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
+++ b/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
@@ -33,6 +33,11 @@ from mcvirt.virtual_machine.hard_drive.factory import Factory as HardDriveFactor
 from mcvirt.node.network import Network
 
 
+class MigrationFailureExcpetion(MCVirtException):
+    """A Libvirt Exception occurred whilst performing a migration"""
+    pass
+
+
 class InvalidVirtualMachineNameException(MCVirtException):
     """VM is being created with an invalid name"""
     pass
@@ -69,8 +74,12 @@ class VmRegisteredElsewhereException(MCVirtException):
 
 
 class VmRunningException(MCVirtException):
-    """An offline migration can only be powered on a powered off VM"""
+    """An offline migration can only be performed on a powered off VM"""
     pass
+
+
+class VmStoppedException(MCVirtException):
+    """An online migraiton can only be performed on a powered on VM"""
 
 
 class UnsuitableNodeException(MCVirtException):
@@ -506,8 +515,10 @@ class VirtualMachine:
             all_domains = mcvirt_object.getLibvirtConnection().listAllDomains()
             return [vm.name() for vm in all_domains]
         else:
-            # TODO Create remote command to return list of VMs registered on other nodes
-            raise NotImplemented()
+            # Return list of VMs registered on remote node
+            cluster_instance = Cluster(mcvirt_object)
+            node = cluster_instance.getRemoteNode(node)
+            return node.runRemoteCommand('virtual_machine-getAllVms', {})
 
     @staticmethod
     def _checkExists(mcvirt_object, name):
@@ -571,7 +582,7 @@ class VirtualMachine:
         self.ensureUnlocked()
 
         # Ensure VM is using a DRBD storage type
-        self._offlineMigratePreMigrateChecks(destination_node_name)
+        self._preMigrationChecks(destination_node_name)
 
         # Check if VM is running
         while (self.getState() is PowerStates.RUNNING):
@@ -605,7 +616,125 @@ class VirtualMachine:
             remote_object.runRemoteCommand('virtual_machine-start',
                                            {'vm_name': self.getName()})
 
-    def _offlineMigratePreMigrateChecks(self, destination_node_name):
+    def onlineMigrate(self, destination_node_name):
+        """Performs an online migration of a VM to another node in the cluster"""
+        from mcvirt.cluster.cluster import Cluster
+
+        # Ensure user has permission to migrate VM
+        self.mcvirt_object.getAuthObject().assertPermission(Auth.PERMISSIONS.MIGRATE_VM, self)
+
+        # Ensure VM is registered locally and unlocked
+        self.ensureRegisteredLocally()
+        self.ensureUnlocked()
+
+        # Perform pre-migration checks
+        self._preMigrationChecks(destination_node_name)
+
+        # Perform online-migration-specific checks
+        self._preOnlineMigrationChecks(destination_node_name)
+
+        # Obtain cluster instance
+        cluster_instance = Cluster(self.mcvirt_object)
+
+        # Begin pre-migration tasks
+        try:
+            # Obtain node object for destination node
+            destination_node = cluster_instance.getRemoteNode(destination_node_name)
+
+            # Obtain libvirt connection to destination node
+            destination_libvirt_connection = self.mcvirt_object.getRemoteLibvirtConnection(
+                destination_node
+            )
+
+            # Clear the VM node configuration
+            self._setNode(None)
+
+            # Perform pre-migration tasks on disk objects
+            for disk_object in self.getDiskObjects():
+                disk_object.preOnlineMigration(destination_node)
+
+            # Build migration flags
+            migration_flags = (
+                # Perform a live migration
+                libvirt.VIR_MIGRATE_LIVE |
+                # The set destination domain as persistent
+                libvirt.VIR_MIGRATE_PERSIST_DEST |
+                # Undefine the domain on the source node
+                libvirt.VIR_MIGRATE_UNDEFINE_SOURCE |
+                # Abort migration on I/O errors
+                libvirt.VIR_MIGRATE_ABORT_ON_ERROR
+            )
+
+            # Perform migration
+            libvirt_domain_object = self._getLibvirtDomainObject()
+            status = libvirt_domain_object.migrate3(
+                destination_libvirt_connection,
+                params={},
+                flags=migration_flags
+            )
+
+            if (not status):
+                raise MigrationFailureExcpetion('Libvirt migration failed')
+
+            # Perform post steps on hard disks and check disks
+            for disk_object in self.getDiskObjects():
+                disk_object.postOnlineMigration()
+                disk_object._checkDrbdStatus()
+
+            # Set the VM node to the destination node node
+            self._setNode(destination_node_name)
+
+        except Exception, e:
+            # Determine which node the VM is present on
+            if (self.getName() in VirtualMachine.getAllVms(self.mcvirt_object,
+                                                           node=Cluster.getHostname())):
+                # VM is registered on the local node.
+                # Set DRBD on remote node to secondary
+                for disk_object in self.getDiskObjects():
+                    cluster_instance.runRemoteCommand(
+                        'virtual_machine-hard_drive-drbd-drbdSetSecondary',
+                        {'vm_name': vm_object.getName(),
+                         'disk_id': hard_drive_object.getConfigObject().getId()},
+                        nodes=[destination_node_name])
+
+            if (self.getName() not in VirtualMachine.getAllVms(self.mcvirt_object,
+                                                               node=destination_node_name)):
+                # Otherwise, if VM is registered on remote node, set the
+                # local DRBD state to secondary
+                for disk_object in self.getDiskObjects():
+                    disk_object._drbdSetSecondary()
+
+            # Reset disks
+            for disk_object in self.getDiskObjects():
+                # Reset dual-primary configuration
+                disk_object._setTwoPrimariesConfig(allow=False)
+
+                # Mark hard drives as being out-of-sync
+                disk_object.setSyncState(False)
+
+            raise e
+
+        # Perform post migration checks
+        # Ensure VM is no longer registered with libvirt on the local node
+        if (self.getName() in VirtualMachine.getAllVms(self.mcvirt_object,
+                                                       node=Cluster.getHostname())):
+            raise VmAlreadyRegisteredException(
+                'The VM is unexpectedly registered with libvirt on the local node: %s' %
+                self.getName()
+            )
+
+        # Ensure VM is registered on the remote libvirt instance
+        if (self.getName() not in VirtualMachine.getAllVms(self.mcvirt_object,
+                                                           node=destination_node_name)):
+            raise VmNotRegistered('The VM is unexpectedly not registered on the remote node: %s' %
+                                  destination_node_name)
+
+        # Ensure VM is running on the remote node
+        if (self.getState() is not PowerStates.RUNNING):
+            raise VmStoppedException('VM is in unexpected %s power state after migration' %
+                                     self.getState())
+
+    def _preMigrationChecks(self, destination_node_name):
         """Performs checks on the state of the VM to determine if is it suitable to
            be migrated"""
         # Ensure node is in the available nodes that the VM can be run on
@@ -622,7 +751,7 @@ class VirtualMachine:
         # Checks the DRBD state of the disks and ensure that they are
         # in a suitable state to be migrated
         for disk_object in self.getDiskObjects():
-            disk_object.offlineMigrateCheckState()
+            disk_object.preMigrationChecks()
 
         # Check the remote node to ensure that the networks, that the VM is connected to,
         # exist on the remote node
@@ -635,6 +764,19 @@ class VirtualMachine:
                     'The network %s does not exist on the remote node: %s' %
                     (connected_network, destination_node_name)
                 )
+
+    def _preOnlineMigrationChecks(self, destination_node_name):
+        """Perform online-migration-specific pre-migration checks"""
+        # Ensure any attached ISOs exist on the destination node
+        disk_drive_object = DiskDrive(self)
+        disk_drive_object.preOnlineMigrationChecks(destination_node_name)
+
+        # Ensure VM is powered on
+        if (self.getState() is not PowerStates.RUNNING):
+            raise VmStoppedException(
+                'An online migration can only be performed on a running VM: %s' %
+                self.getName()
+            )
 
     def getStorageType(self):
         """Returns the storage type of the VM"""

--- a/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
+++ b/source/usr/lib/mcvirt/virtual_machine/virtual_machine.py
@@ -726,8 +726,10 @@ class VirtualMachine:
         # Ensure VM is registered on the remote libvirt instance
         if (self.getName() not in VirtualMachine.getAllVms(self.mcvirt_object,
                                                            node=destination_node_name)):
-            raise VmNotRegistered('The VM is unexpectedly not registered on the remote node: %s' %
-                                  destination_node_name)
+            raise VmNotRegistered(
+                'The VM is unexpectedly not registered with libvirt on the destination node: %s' %
+                destination_node_name
+            )
 
         # Ensure VM is running on the remote node
         if (self.getState() is not PowerStates.RUNNING):


### PR DESCRIPTION
* Added functionality to perform the following:
  * Configure DRBD primary status on remote nodes
  * Configure 'allow-two-primaries' on local and remote nodes
  * List VMs registered with Libvirt on remote nodes
  * List ISOs present to remote nodes
  * Create and cache Libvirt connection to remote nodes

Unit tests are still to be written