### PR TITLE
Split user guide by use-case

### DIFF
--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -1,0 +1,39 @@
+=============
+Configuration
+=============
+
+Configure Network
+-----------------
+
+Remove default network
+``````````````````````
+
+* By default, libvirt configures a default network, 'default'.
+* This can be removed by performing the following::
+
+    sudo mcvirt network delete default
+
+Creating/Removing Network
+`````````````````````````
+
+* Networks provide bridges between physical interfaces and virtual machines.
+* To create a network on the node, perform the following as a superuser::
+
+    sudo mcvirt network create <Network name> --interface <Physical interface>
+
+
+* Assuming that there are not any VMs connected to a network, they can be removed using::
+
+    sudo mcvirt network delete <Network name>
+
+Configure MCVirt
+-----------------
+
+* The first time MCVirt is run, it creates a configuration file for itself, found in **/var/lib/mcvirt/<Hostname>/config.json**.
+* The volume group, in which VM data will be stored as logical volumes, must be setup using::
+
+    sudo mcvirt node --set-vm-vg <Volume Group>
+
+* The cluster IP address must be configured if the node will be used in a cluster (See the `Cluster documentation <Cluster.rst>`_)::
+
+    sudo mcvirt node --set-ip-address <Cluster IP Address>

--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -20,8 +20,9 @@ Creating/Removing Networks
 
 * Networks provide bridges between physical/bridge interfaces and virtual machines.
 * To create a bridge network on the node, an additional network interface will need to be created on the node
-  * This will generally be placed in `/etc/network/interfaces`.
-  * The following example should help with creating this interface::
+* This will generally be placed in `/etc/network/interfaces`
+
+The following example should help with creating this interface::
 
     auto vmbr0
     iface vmbr0 inet manual

--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -9,17 +9,32 @@ Remove default network
 ``````````````````````
 
 * By default, libvirt configures a default network, 'default'.
-* This can be removed by performing the following::
+* The 'default' network is attached to a private network, which provides NAT routing through the node's physical interfaces.
+* If you wish to use bridging, the default network can be removed by performing the following::
 
     sudo mcvirt network delete default
 
-Creating/Removing Network
-`````````````````````````
 
-* Networks provide bridges between physical interfaces and virtual machines.
+Creating/Removing Networks
+``````````````````````````
+
+* Networks provide bridges between physical/bridge interfaces and virtual machines.
+* To create a bridge network on the node, an additional network interface will need to be created on the node
+  * This will generally be placed in `/etc/network/interfaces`.
+  * The following example should help with creating this interface::
+
+    auto vmbr0
+    iface vmbr0 inet manual
+      bridge_ports <Physical interface>
+      bridge_stp off
+      bridge_fd 0
+
+Where `<Physical interface>` is the name of the interface that the bridge should be bridged with, e.g. 'eth0'
+
+
 * To create a network on the node, perform the following as a superuser::
 
-    sudo mcvirt network create <Network name> --interface <Physical interface>
+    sudo mcvirt network create <Network name> --interface <Bridge interface>
 
 
 * Assuming that there are not any VMs connected to a network, they can be removed using::

--- a/Documentation/Installation.rst
+++ b/Documentation/Installation.rst
@@ -41,34 +41,3 @@ Additionally, ``NOPASSWD:`` can be used to allow users to run MCVirt without hav
 
     example_user ALL=(ALL) NOPASSWD: /usr/bin/mcvirt
 
-
-Configure Network
------------------
-
-Remove default network
-``````````````````````
-
-* By default, libvirt configures a default network, 'default'.
-* This can be removed by performing the following::
-
-    sudo mcvirt network delete default
-
-Creating/Removing Network
-`````````````````````````
-
-* Networks provide bridges between physical interfaces and virtual machines.
-* To create a network on the node, perform the following as a superuser::
-
-    sudo mcvirt network create <Network name> --interface <Physical interface>
-
-
-* Assuming that there are not any VMs connected to a network, they can be removed using::
-
-    sudo mcvirt network delete <Network name>
-
-Configure MCVirt
------------------
-
-* The first time MCVirt is run, it creates a configuration file for itself, found in **/var/lib/mcvirt/<Hostname>/config.json**.
-* Set ``vm_storage_vg`` in the configuration file to the name of volume group for the VMs to be stored in.
-* Set ``cluster_ip`` in the configuration file to the IP address of the node that MCVirt clustering/DRBD communications will be performed on.

--- a/Documentation/MCVirt.rst
+++ b/Documentation/MCVirt.rst
@@ -1,17 +1,35 @@
-======
-MCVirt
-======
-
-
-
-
+===========
 User Guides
------------
+===========
 
+Installation
+------------
 
 * `Installation <Installation.rst>`_ - Procedure for building the MCVirt package, setting up a node with MCVirt and performing initial configuration
+
+
+Configuration
+-------------
+
+* `Configuration <Configuration.rst>`_ - Procedures for performing initial configurations of an MCVirt installation
+
+
+Administration
+--------------
+
+* `Permissions <Permissions.rst>`_ - Procedures for configuring permissions within MCVirt
+* `Cluster <Cluster.rst>`_ - Procedures for configuring an MCVirt Cluster
+
+
+Usage
+-----
+
 * `Create/Remove VMs <CreateRemoveVMs.rst>`_ - Procedures for creating and deleting virtual machines
 * `Controlling VMs <ControllingVMs.rst>`_ - Instructions for using the MCVirt script and controlling virtual machines
 * `Modifying VMs <ModifyingVMs.rst>`_ - Procedures for making changes to virtual machine configurations
-* `Permissions <Permissions.rst>`_ - Procedures for configuring permissions within MCVirt
-* `Cluster <Cluster.rst>`_ - Procedures for configuring an MCVirt Cluster
+
+
+Development
+-----------
+
+* `Development <Development.rst>`_ - Information about performing development on MCVirt

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Add the volume group to be used for VM disks in the global MCVirt configuration:
   $ vim /var/lib/mcvirt/`hostname`/config.json
 
 
-See the `installation guide <Documentation/Installation.rst>`_ for further node configuration steps.
+See the `configuration guide <Documentation/Configuration.rst.rst>`_ for further node configuration steps.
 
 Usage
 -----
@@ -62,6 +62,12 @@ Development
 -----------
 
 For information on developing on MCVirt, see the `development documentation <Documentation/Development.rst>`_.
+
+
+Further information
+-------------------
+
+See the `guide index <Documentation/MCVirt.rst>`_ for a full list of manuals
 
 
 LICENSE


### PR DESCRIPTION
Moved configuration documentation into seperate RST file

* Installation
* Configuration
* User guide
* Development

User guide should be split by use case #2