### PR TITLE
Fixed comparison of directory name ('is' vs '=='), which caused the wrong permissions to be applied to the '.git' directory

### DIFF
--- a/source/usr/lib/mcvirt/config_file.py
+++ b/source/usr/lib/mcvirt/config_file.py
@@ -93,7 +93,7 @@ class ConfigFile():
         for directory in os.listdir(MCVirt.BASE_STORAGE_DIR):
             path = os.path.join(MCVirt.BASE_STORAGE_DIR, directory)
             if (os.path.isdir(path)):
-                if (directory is '.git'):
+                if (directory == '.git'):
                     setPermission(path, directory=True)
                 else:
                     setPermission(os.path.join(path, 'vm'), directory=True)


### PR DESCRIPTION
Fix issue when permissions are set on git-backed config repositories #140