### PR TITLE
User managment

### DIFF
--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -18,14 +18,14 @@
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
 from mcvirt.auth.user_base import UserBase
-from mcvirt.exceptions import OldPasswordIncorrect
+
+import Pyro4
 
 
 class User(UserBase):
     """Provides an interaction with the local user backend"""
 
-    def change_password(self, old_password, new_password):
+    @Pyro4.expose()
+    def change_password(self, new_password):
         """Change the current user's password."""
-        if not self._check_password(old_password):
-            raise OldPasswordIncorrect('Old password is not correct')
         self._set_password(new_password)

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -27,7 +27,7 @@ class User(UserBase):
     """Provides an interaction with the local user backend"""
 
     @Pyro4.expose()
-    def change_password(self, new_password):
+    def set_password(self, new_password):
         """Change the current user's password."""
         # Check that the current user is the same as this user, or that current user has the correct
         # permissions

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
+import Pyro4
+
 from mcvirt.auth.user_base import UserBase
 from mcvirt.auth.permissions import PERMISSIONS
-
-import Pyro4
 
 
 class User(UserBase):

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -18,6 +18,7 @@
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
 from mcvirt.auth.user_base import UserBase
+from mcvirt.auth.permissions import PERMISSIONS
 
 import Pyro4
 
@@ -28,4 +29,10 @@ class User(UserBase):
     @Pyro4.expose()
     def change_password(self, new_password):
         """Change the current user's password."""
+        # Check that the current user is the same as this user, or that current user has the correct
+        # permissions
+        actual_user = self._get_registered_object('mcvirt_session').get_proxy_user_object()
+        if actual_user.get_username() != self.get_username():
+            self._get_registered_object('auth').assert_permission(PERMISSIONS.MANAGE_USERS)
+
         self._set_password(new_password)

--- a/source/usr/lib/mcvirt/auth/user_base.py
+++ b/source/usr/lib/mcvirt/auth/user_base.py
@@ -111,7 +111,7 @@ class UserBase(PyroObject):
                 remote_user_factory = node_connection.get_connection('user_factory')
                 remote_user = remote_user_factory.get_user_by_username(self.get_username())
                 node_connection.annotate_object(remote_user)
-                remote_user.change_password(new_password)
+                remote_user.set_password(new_password)
 
             cluster = self._get_registered_object('cluster')
             cluster.run_remote_command(remote_command)

--- a/source/usr/lib/mcvirt/auth/user_base.py
+++ b/source/usr/lib/mcvirt/auth/user_base.py
@@ -98,6 +98,12 @@ class UserBase(PyroObject):
 
     def _set_password(self, new_password):
         """Set the password for the current user"""
+        # Check that the current user is the same as this user, or that current user has the correct
+        # permissions
+        actual_user = self._get_registered_object('mcvirt_session').get_current_user_object()
+        if actual_user.get_username() != self.get_username():
+            self._get_registered_object('auth').assert_permission(PERMISSIONS.MANAGE_USERS)
+
         password_hash = self._hash_password(new_password)
 
         def update_config(config):

--- a/source/usr/lib/mcvirt/exceptions.py
+++ b/source/usr/lib/mcvirt/exceptions.py
@@ -154,8 +154,8 @@ class UserDoesNotExistException(MCVirtException):
     pass
 
 
-class OldPasswordIncorrect(MCVirtException):
-    """The old password is not correct"""
+class PasswordsDoNotMatchException(MCVirtException):
+    """The new passwords do not match"""
 
     pass
 

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -119,6 +119,12 @@ class Parser(object):
             metavar='New password',
             help='The new password'
         )
+        self.change_password_subparser.add_argument(
+            '--target-user',
+            dest='target_user',
+            metavar='Target user',
+            help='The user to change the password of'
+        )
 
         # Add arguments for creating a VM
         self.create_parser = self.subparsers.add_parser('create', help='Create VM',
@@ -973,7 +979,8 @@ class Parser(object):
         elif action == 'user':
             if args.user_action == 'change-password':
                 user_factory = rpc.get_connection('user_factory')
-                user = user_factory.get_user_by_username(Parser.USERNAME)
+                target_user = args.target_user or Parser.USERNAME
+                user = user_factory.get_user_by_username(target_user)
                 rpc.annotate_object(user)
 
                 if args.new_password:
@@ -983,4 +990,5 @@ class Parser(object):
                     repeat_password = System.getUserInput("New password (repeat): ", password=True)
                     if new_password != repeat_password:
                         raise PasswordsDoNotMatchException('The two passwords do not match')
+
                 user.change_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -109,6 +109,12 @@ class Parser(object):
             action='store_true',
             help='Change password'
         )
+        self.user_parser.add_argument(
+            '--new-password',
+            dest='new_password',
+            metavar='New password',
+            help='The new password'
+        )
 
         # Add arguments for creating a VM
         self.create_parser = self.subparsers.add_parser('create', help='Create VM',
@@ -961,12 +967,16 @@ class Parser(object):
                 self.print_status('Successfully removed iso: %s' % args.delete_path)
 
         elif action == 'user':
-            user_factory = rpc.get_connection('user_factory')
-            user = user_factory.get_user_by_username(Parser.USERNAME)
-            rpc.annotate_object(user)
+            if args.change_password:
+                user_factory = rpc.get_connection('user_factory')
+                user = user_factory.get_user_by_username(Parser.USERNAME)
+                rpc.annotate_object(user)
 
-            new_password = System.getUserInput("New password: ", password=True)
-            repeat_password = System.getUserInput("New password (repeat): ", password=True)
-            if new_password != repeat_password:
-                raise PasswordsDoNotMatchException('The two passwords do not match')
-            user.change_password(new_password)
+                if args.new_password:
+                    new_password = args.new_password
+                else:
+                    new_password = System.getUserInput("New password: ", password=True)
+                    repeat_password = System.getUserInput("New password (repeat): ", password=True)
+                    if new_password != repeat_password:
+                        raise PasswordsDoNotMatchException('The two passwords do not match')
+                user.change_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -991,4 +991,4 @@ class Parser(object):
                     if new_password != repeat_password:
                         raise PasswordsDoNotMatchException('The two passwords do not match')
 
-                user.change_password(new_password)
+                user.set_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -103,13 +103,17 @@ class Parser(object):
         # Add arguments for managing users
         self.user_parser = self.subparsers.add_parser('user', help='User managment',
                                                       parents=[self.parent_parser])
-        self.user_parser.add_argument(
-            '--change-password',
-            dest='change_password',
-            action='store_true',
-            help='Change password'
+        self.user_subparser = self.user_parser.add_subparsers(
+            dest='user_action',
+            help='User managment action to perform',
+            metavar='Action'
         )
-        self.user_parser.add_argument(
+        self.change_password_subparser = self.user_subparser.add_parser(
+            'change-password',
+            help='Change a user password',
+            parents=[self.parent_parser]
+        )
+        self.change_password_subparser.add_argument(
             '--new-password',
             dest='new_password',
             metavar='New password',
@@ -967,7 +971,7 @@ class Parser(object):
                 self.print_status('Successfully removed iso: %s' % args.delete_path)
 
         elif action == 'user':
-            if args.change_password:
+            if args.user_action == 'change-password':
                 user_factory = rpc.get_connection('user_factory')
                 user = user_factory.get_user_by_username(Parser.USERNAME)
                 rpc.annotate_object(user)


### PR DESCRIPTION
Allow user passwords to be changed, e.g.:
```
$ mcvirt user change-password
Username: joe
Password:
New password:
New password (repeat):
```
The new password can also be provided with `--new-password`. Superusers can also change other people's passwords with `--target-user`