### PR TITLE
Allow superusers to create and remove users

### DIFF
--- a/source/usr/lib/mcvirt/auth/factory.py
+++ b/source/usr/lib/mcvirt/auth/factory.py
@@ -22,7 +22,7 @@ import Pyro4
 from mcvirt.mcvirt_config import MCVirtConfig
 from mcvirt.exceptions import (IncorrectCredentials, InvalidUsernameException,
                                UserDoesNotExistException, InvalidUserTypeException,
-                               UserAlreadyExistsException)
+                               UserAlreadyExistsException, BlankPasswordException)
 from mcvirt.rpc.pyro_object import PyroObject
 from mcvirt.auth.user_base import UserBase
 from mcvirt.auth.user import User
@@ -49,6 +49,9 @@ class Factory(PyroObject):
         self._get_registered_object('auth').assert_permission(
             PERMISSIONS.MANAGE_USERS
         )
+
+        if password == '':
+            raise BlankPasswordException('Password cannot be blank')
 
         # Ensure that username is not part of a reserved namespace
         for user_class in self.get_user_types():

--- a/source/usr/lib/mcvirt/auth/factory.py
+++ b/source/usr/lib/mcvirt/auth/factory.py
@@ -43,6 +43,7 @@ class Factory(PyroObject):
         if user_type not in self.get_user_types():
             raise InvalidUserTypeException('An invalid user type has been passed')
 
+    @Pyro4.expose()
     def create(self, username, password, user_type=User):
         """Create a user."""
         self._get_registered_object('auth').assert_permission(
@@ -79,6 +80,15 @@ class Factory(PyroObject):
         def update_config(config):
             config['users'][username] = user_config
         MCVirtConfig().update_config(update_config, 'Create user \'%s\'' % username)
+
+        if user_type == User and self._is_cluster_master:
+            # Create the user on the other nodes in the cluster
+            def remote_command(node_connection):
+                remote_user_factory = node_connection.get_connection('user_factory')
+                remote_user_factory.create(username, password)
+
+            cluster = self._get_registered_object('cluster')
+            cluster.run_remote_command(remote_command)
 
     @Pyro4.expose()
     def add_config(self, username, user_config):

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -18,14 +18,14 @@
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
 from mcvirt.auth.user_base import UserBase
-from mcvirt.exceptions import OldPasswordIncorrect
+
+import Pyro4
 
 
 class User(UserBase):
     """Provides an interaction with the local user backend"""
 
-    def change_password(self, old_password, new_password):
+    @Pyro4.expose()
+    def change_password(self, new_password):
         """Change the current user's password."""
-        if not self._check_password(old_password):
-            raise OldPasswordIncorrect('Old password is not correct')
         self._set_password(new_password)

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -27,7 +27,7 @@ class User(UserBase):
     """Provides an interaction with the local user backend"""
 
     @Pyro4.expose()
-    def change_password(self, new_password):
+    def set_password(self, new_password):
         """Change the current user's password."""
         # Check that the current user is the same as this user, or that current user has the correct
         # permissions

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -17,10 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
+import Pyro4
+
 from mcvirt.auth.user_base import UserBase
 from mcvirt.auth.permissions import PERMISSIONS
-
-import Pyro4
 
 
 class User(UserBase):

--- a/source/usr/lib/mcvirt/auth/user.py
+++ b/source/usr/lib/mcvirt/auth/user.py
@@ -18,6 +18,7 @@
 # along with MCVirt.  If not, see <http://www.gnu.org/licenses/>
 
 from mcvirt.auth.user_base import UserBase
+from mcvirt.auth.permissions import PERMISSIONS
 
 import Pyro4
 
@@ -28,4 +29,10 @@ class User(UserBase):
     @Pyro4.expose()
     def change_password(self, new_password):
         """Change the current user's password."""
+        # Check that the current user is the same as this user, or that current user has the correct
+        # permissions
+        actual_user = self._get_registered_object('mcvirt_session').get_proxy_user_object()
+        if actual_user.get_username() != self.get_username():
+            self._get_registered_object('auth').assert_permission(PERMISSIONS.MANAGE_USERS)
+
         self._set_password(new_password)

--- a/source/usr/lib/mcvirt/auth/user_base.py
+++ b/source/usr/lib/mcvirt/auth/user_base.py
@@ -160,6 +160,16 @@ class UserBase(PyroObject):
             del config['users'][self.get_username()]
         MCVirtConfig().update_config(update_config, 'Deleted user \'%s\'' % self.get_username())
 
+        if self._is_cluster_master:
+            def remote_command(node_connection):
+                remote_user_factory = node_connection.get_connection('user_factory')
+                remote_user = remote_user_factory.get_user_by_username(self.get_username())
+                node_connection.annotate_object(remote_user)
+                remote_user.delete()
+
+            cluster = self._get_registered_object('cluster')
+            cluster.run_remote_command(remote_command)
+
     @staticmethod
     def get_default_config():
         """Return the default configuration for the user type."""

--- a/source/usr/lib/mcvirt/auth/user_base.py
+++ b/source/usr/lib/mcvirt/auth/user_base.py
@@ -111,7 +111,7 @@ class UserBase(PyroObject):
                 remote_user_factory = node_connection.get_connection('user_factory')
                 remote_user = remote_user_factory.get_user_by_username(self.get_username())
                 node_connection.annotate_object(remote_user)
-                remote_user.change_password(new_password)
+                remote_user.set_password(new_password)
 
             cluster = self._get_registered_object('cluster')
             cluster.run_remote_command(remote_command)

--- a/source/usr/lib/mcvirt/auth/user_base.py
+++ b/source/usr/lib/mcvirt/auth/user_base.py
@@ -98,6 +98,12 @@ class UserBase(PyroObject):
 
     def _set_password(self, new_password):
         """Set the password for the current user"""
+        # Check that the current user is the same as this user, or that current user has the correct
+        # permissions
+        actual_user = self._get_registered_object('mcvirt_session').get_current_user_object()
+        if actual_user.get_username() != self.get_username():
+            self._get_registered_object('auth').assert_permission(PERMISSIONS.MANAGE_USERS)
+
         password_hash = self._hash_password(new_password)
 
         def update_config(config):

--- a/source/usr/lib/mcvirt/exceptions.py
+++ b/source/usr/lib/mcvirt/exceptions.py
@@ -154,8 +154,8 @@ class UserDoesNotExistException(MCVirtException):
     pass
 
 
-class OldPasswordIncorrect(MCVirtException):
-    """The old password is not correct"""
+class PasswordsDoNotMatchException(MCVirtException):
+    """The new passwords do not match"""
 
     pass
 

--- a/source/usr/lib/mcvirt/exceptions.py
+++ b/source/usr/lib/mcvirt/exceptions.py
@@ -550,6 +550,12 @@ class UserAlreadyExistsException(MCVirtException):
     pass
 
 
+class BlankPasswordException(MCVirtException):
+    """The provided password is blank"""
+
+    pass
+
+
 for exception_class in get_all_submodules(MCVirtException):
     Pyro4.util.all_exceptions[
         '%s.%s' % (exception_class.__module__, exception_class.__name__)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -119,6 +119,12 @@ class Parser(object):
             metavar='New password',
             help='The new password'
         )
+        self.change_password_subparser.add_argument(
+            '--target-user',
+            dest='target_user',
+            metavar='Target user',
+            help='The user to change the password of'
+        )
 
         # Add arguments for creating a VM
         self.create_parser = self.subparsers.add_parser('create', help='Create VM',
@@ -973,7 +979,8 @@ class Parser(object):
         elif action == 'user':
             if args.user_action == 'change-password':
                 user_factory = rpc.get_connection('user_factory')
-                user = user_factory.get_user_by_username(Parser.USERNAME)
+                target_user = args.target_user or Parser.USERNAME
+                user = user_factory.get_user_by_username(target_user)
                 rpc.annotate_object(user)
 
                 if args.new_password:
@@ -983,4 +990,5 @@ class Parser(object):
                     repeat_password = System.getUserInput("New password (repeat): ", password=True)
                     if new_password != repeat_password:
                         raise PasswordsDoNotMatchException('The two passwords do not match')
+
                 user.change_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -109,6 +109,12 @@ class Parser(object):
             action='store_true',
             help='Change password'
         )
+        self.user_parser.add_argument(
+            '--new-password',
+            dest='new_password',
+            metavar='New password',
+            help='The new password'
+        )
 
         # Add arguments for creating a VM
         self.create_parser = self.subparsers.add_parser('create', help='Create VM',
@@ -961,12 +967,16 @@ class Parser(object):
                 self.print_status('Successfully removed iso: %s' % args.delete_path)
 
         elif action == 'user':
-            user_factory = rpc.get_connection('user_factory')
-            user = user_factory.get_user_by_username(Parser.USERNAME)
-            rpc.annotate_object(user)
+            if args.change_password:
+                user_factory = rpc.get_connection('user_factory')
+                user = user_factory.get_user_by_username(Parser.USERNAME)
+                rpc.annotate_object(user)
 
-            new_password = System.getUserInput("New password: ", password=True)
-            repeat_password = System.getUserInput("New password (repeat): ", password=True)
-            if new_password != repeat_password:
-                raise PasswordsDoNotMatchException('The two passwords do not match')
-            user.change_password(new_password)
+                if args.new_password:
+                    new_password = args.new_password
+                else:
+                    new_password = System.getUserInput("New password: ", password=True)
+                    repeat_password = System.getUserInput("New password (repeat): ", password=True)
+                    if new_password != repeat_password:
+                        raise PasswordsDoNotMatchException('The two passwords do not match')
+                user.change_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -136,13 +136,16 @@ class Parser(object):
             type=str,
             help='The new user to create'
         )
-        self.create_user_subparser.add_argument(
+        self.create_user_mut_ex_group = self.create_user_subparser.add_mutually_exclusive_group(
+            required=False
+         )
+        self.create_user_mut_ex_group.add_argument(
             '--user-password',
             dest='new_user_password',
             metavar='New password',
             help='The password for the new user'
         )
-        self.create_user_subparser.add_argument(
+        self.create_user_mut_ex_group.add_argument(
             '--generate-password',
             dest='generate_password',
             action='store_true',

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -148,6 +148,17 @@ class Parser(object):
             action='store_true',
             help='Generate a password for the new user'
         )
+        self.remove_user_subparser = self.user_subparser.add_parser(
+            'remove',
+            help='Remove a user',
+            parents=[self.parent_parser]
+        )
+        self.remove_user_subparser.add_argument(
+            'remove_username',
+            metavar='User',
+            type=str,
+            help='The user to remove'
+        )
 
         # Add arguments for creating a VM
         self.create_parser = self.subparsers.add_parser('create', help='Create VM',
@@ -1021,3 +1032,9 @@ class Parser(object):
                 self.print_status('New user details:\nUsername: %s' % args.new_username)
                 if args.generate_password:
                     self.print_status('Password: %s' % new_password)
+
+            elif args.user_action == 'remove':
+                user_factory = rpc.get_connection('user_factory')
+                user = user_factory.get_user_by_username(args.remove_username)
+                rpc.annotate_object(user)
+                user.delete()

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -991,4 +991,4 @@ class Parser(object):
                     if new_password != repeat_password:
                         raise PasswordsDoNotMatchException('The two passwords do not match')
 
-                user.change_password(new_password)
+                user.set_password(new_password)

--- a/source/usr/lib/mcvirt/parser.py
+++ b/source/usr/lib/mcvirt/parser.py
@@ -103,13 +103,17 @@ class Parser(object):
         # Add arguments for managing users
         self.user_parser = self.subparsers.add_parser('user', help='User managment',
                                                       parents=[self.parent_parser])
-        self.user_parser.add_argument(
-            '--change-password',
-            dest='change_password',
-            action='store_true',
-            help='Change password'
+        self.user_subparser = self.user_parser.add_subparsers(
+            dest='user_action',
+            help='User managment action to perform',
+            metavar='Action'
         )
-        self.user_parser.add_argument(
+        self.change_password_subparser = self.user_subparser.add_parser(
+            'change-password',
+            help='Change a user password',
+            parents=[self.parent_parser]
+        )
+        self.change_password_subparser.add_argument(
             '--new-password',
             dest='new_password',
             metavar='New password',
@@ -967,7 +971,7 @@ class Parser(object):
                 self.print_status('Successfully removed iso: %s' % args.delete_path)
 
         elif action == 'user':
-            if args.change_password:
+            if args.user_action == 'change-password':
                 user_factory = rpc.get_connection('user_factory')
                 user = user_factory.get_user_by_username(Parser.USERNAME)
                 rpc.annotate_object(user)

--- a/source/usr/lib/mcvirt/system.py
+++ b/source/usr/lib/mcvirt/system.py
@@ -56,7 +56,8 @@ class System(object):
     @staticmethod
     def getNewPassword():
         """Prompts the user for a new password, throwing an exception is the password is not
-           repeated correctly"""
+        repeated correctly
+        """
         new_password = System.getUserInput("New password: ", password=True)
         repeat_password = System.getUserInput("New password (repeat): ", password=True)
         if new_password != repeat_password:

--- a/source/usr/lib/mcvirt/system.py
+++ b/source/usr/lib/mcvirt/system.py
@@ -19,7 +19,7 @@ import getpass
 import subprocess
 import sys
 
-from mcvirt.exceptions import MCVirtCommandException
+from mcvirt.exceptions import MCVirtCommandException, PasswordsDoNotMatchException
 
 
 class System(object):
@@ -52,3 +52,14 @@ class System(object):
         else:
             sys.stdout.write(display_text)
             return sys.stdin.readline()
+
+    @staticmethod
+    def getNewPassword():
+        """Prompts the user for a new password, throwing an exception is the password is not
+           repeated correctly"""
+        new_password = System.getUserInput("New password: ", password=True)
+        repeat_password = System.getUserInput("New password (repeat): ", password=True)
+        if new_password != repeat_password:
+            raise PasswordsDoNotMatchException('The two passwords do not match')
+
+        return new_password


### PR DESCRIPTION
Superusers can now create new users with
`$ mcvirt user create <new username>`
The password for the new user can be provided with `--user-password=<new password>`, generated for you with `--generate-password` (the password is printed out afterwards) or typed in interactively.

Superusers can also remove users with
`$ mcvirt user remove <username>`